### PR TITLE
Dockerize

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+*Dockerfile*
+*docker-compose*
+node_modules/
+dist/
+.cache/
+results/

--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,4 @@ test/integration/.spoke-server
 test/integration/project/generated
 .tersercache
 results/
-
 .cache/

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ test/integration/.spoke-server
 test/integration/project/generated
 .tersercache
 results/
+
+.cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+language: node_js
+node_js:
+  - "10"
+
+services:
+  - docker
+
+script:
+  - yarn test
+
+before_deploy:
+  - scripts/setup_helm.sh
+  - scripts/setup_aws.sh $AWS_ACCESS_KEY $AWS_SECRET $AWS_REIGON $CLUSTER_NAME
+
+deploy:
+  - provider: script
+    script: bash scripts/publish_dockerhub.sh staging $TRAVIS_COMMIT && scripts/deploy.sh staging $TRAVIS_COMMIT
+    on:
+      branch: master
+  - provider: script
+    script: bash scripts/publish_dockerhub.sh dev $TRAVIS_COMMIT && scripts/deploy.sh dev $TRAVIS_COMMIT
+    on:
+      branch: dev
+  - provider: script
+    script: bash scripts/publish_dockerhub.sh latest $TRAVIS_TAG 
+    on:
+      tags: true
+      all_branches: true
+
+after_success:
+  - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
+  - chmod +x send.sh
+  - ./send.sh success $WEBHOOK_URL
+after_failure:
+  - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
+  - chmod +x send.sh
+  - ./send.sh failure $WEBHOOK_URL
+
+cache: yarn

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+# build stage
+FROM node:10 as build-stage
+
+
+# hubs modules
+WORKDIR /spoke
+COPY package*.json /spoke/
+COPY yarn.lock /spoke/
+RUN yarn install 
+#--frozen-lockfile
+
+COPY . /spoke/
+WORKDIR /spoke
+
+
+RUN bash ./scripts/write_env_stub.sh
+RUN  yarn build
+RUN mkdir -p dist/pages
+# RUN mv dist/*.html dist/pages
+
+
+# production stage
+FROM nginx:stable as production-stage
+
+COPY scripts/nginx.conf /etc/nginx/conf.d/default.conf
+COPY scripts/ /spoke/scripts/
+COPY --from=build-stage /spoke/dist /spoke/dist
+
+ENV NODE_TLS_REJECT_UNAUTHORIZED=0
+ENV ROUTER_BASE_PATH=/
+
+ENV BASE_ASSETS_PATH=http://xrchat.local/ 
+ENV HUBS_SERVER=xrchat.local:4000
+ENV RETICULUM_SERVER=xrchat.local:4000
+ENV THUMBNAIL_SERVER=
+ENV CORS_PROXY_SERVER=
+ENV NON_CORS_PROXY_DOMAINS=
+ENV SENTRY_DSN=
+ENV GA_TRACKING_ID=
+ENV IS_MOZ=false
+
+
+
+EXPOSE 80
+EXPOSE 443
+
+
+WORKDIR /spoke
+RUN ./scripts/replace_env_stub.sh
+RUN cp -r /spoke/dist/. /usr/share/nginx/html/
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile.habitat
+++ b/Dockerfile.habitat
@@ -1,0 +1,41 @@
+# build stage
+# FROM habitat/default-studio-x86_64-linux:1.6.2
+FROM alpine
+RUN apk add --no-cache curl bash
+RUN curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | bash
+
+# hubs modules
+COPY . /spoke/
+
+RUN hab license accept 
+RUN hab studio  run build /spoke --verbose
+
+# production stage
+FROM nginx:stable as production-stage
+
+COPY scripts/ /spoke/scripts/
+COPY --from=build-stage /spoke/dist /spoke/dist
+
+ENV NODE_TLS_REJECT_UNAUTHORIZED=0
+ENV ROUTER_BASE_PATH=/
+ENV BASE_ASSETS_PATH=http://xrchat.local/ 
+ENV HUBS_SERVER=xrchat.local:4000
+ENV RETICULUM_SERVER=xrchat.local:4000
+
+ENV BASE_ASSETS_PATH=
+ENV HUBS_SERVER=
+ENV RETICULUM_SERVER=
+ENV THUMBNAIL_SERVER=
+ENV CORS_PROXY_SERVER=
+ENV NON_CORS_PROXY_DOMAINS=
+ENV SENTRY_DSN=
+ENV GA_TRACKING_ID=
+ENV IS_MOZ=false
+
+
+WORKDIR /spoke
+RUN ./scripts/replace_env_stub.sh
+RUN cp /spoke/dist /usr/share/nginx/html
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Then open **https://localhost:9090** (note: HTTPS is required).
 
 When running against a local self-signed cert reticulum server, you'll need to `export NODE_TLS_REJECT_UNAUTHORIZED=0` for publishing to work.
 
+## Docker
+
+To run inside a docker container, check [Dockerizing Spoke](docs/dockerize.md) document.
+
 ## Credits
 
 Parts of this project are derived from the [three.js editor](https://threejs.org/editor/)

--- a/docs/dockerize.md
+++ b/docs/dockerize.md
@@ -1,0 +1,42 @@
+# Runing Spoke inside docker container
+
+There are 2 docker flavours if this repo:
+
+1. Dockerfile generated repo, with just dependeicies on NodeJS and Nginx.
+2. Habitat generated image, that uses Chef Habitat to build, run, configure, and supervise the spoke web server at runtime.
+
+
+## Dockerfile generated image
+
+You can run it using docker, if you don't have node installed or need to test.
+``` bash
+# Build the image
+docker build --tag spoke .
+
+# Run the image (deletes itself when you close it)
+docker run -d --rm --name spoke -e "HUBS_SERVER=xrchat.local" -p "8080:80"  spoke
+
+# Stop the server
+docker stop spoke
+```
+
+### Docker image configurations
+
+Enviroment variables:
+- BASE_ASSETS_PATH: [http://xrchat.local/]
+- HUBS_SERVER: [xrchat.local:4000]
+- RETICULUM_SERVER: [xrchat.local:4000]
+- THUMBNAIL_SERVER: []
+- CORS_PROXY_SERVER: []
+- NON_CORS_PROXY_DOMAINS: []
+- SENTRY_DSN: []
+- GA_TRACKING_ID: []
+- IS_MOZ: [false]
+
+
+## Habitat generated image
+
+This relies on Chef Habitat Builder (Acting as a CI and a build system)
+Habitat builder pulls the repo from github #master then builds the image.
+
+docker run -it --rm --env HAB_LICENSE=accept-no-persist  xrchat/spoke

--- a/habitat/config/mime.types
+++ b/habitat/config/mime.types
@@ -1,0 +1,97 @@
+
+types {
+    text/html                                        html htm shtml;
+    text/css                                         css;
+    text/xml                                         xml;
+    image/gif                                        gif;
+    image/jpeg                                       jpeg jpg;
+    application/javascript                           js;
+    application/atom+xml                             atom;
+    application/rss+xml                              rss;
+
+    text/mathml                                      mml;
+    text/plain                                       txt;
+    text/vnd.sun.j2me.app-descriptor                 jad;
+    text/vnd.wap.wml                                 wml;
+    text/x-component                                 htc;
+
+    image/png                                        png;
+    image/svg+xml                                    svg svgz;
+    image/tiff                                       tif tiff;
+    image/vnd.wap.wbmp                               wbmp;
+    image/webp                                       webp;
+    image/x-icon                                     ico;
+    image/x-jng                                      jng;
+    image/x-ms-bmp                                   bmp;
+
+    font/woff                                        woff;
+    font/woff2                                       woff2;
+
+    application/java-archive                         jar war ear;
+    application/json                                 json;
+    application/mac-binhex40                         hqx;
+    application/msword                               doc;
+    application/pdf                                  pdf;
+    application/postscript                           ps eps ai;
+    application/rtf                                  rtf;
+    application/vnd.apple.mpegurl                    m3u8;
+    application/vnd.google-earth.kml+xml             kml;
+    application/vnd.google-earth.kmz                 kmz;
+    application/vnd.ms-excel                         xls;
+    application/vnd.ms-fontobject                    eot;
+    application/vnd.ms-powerpoint                    ppt;
+    application/vnd.oasis.opendocument.graphics      odg;
+    application/vnd.oasis.opendocument.presentation  odp;
+    application/vnd.oasis.opendocument.spreadsheet   ods;
+    application/vnd.oasis.opendocument.text          odt;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation
+                                                     pptx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+                                                     xlsx;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+                                                     docx;
+    application/vnd.wap.wmlc                         wmlc;
+    application/x-7z-compressed                      7z;
+    application/x-cocoa                              cco;
+    application/x-java-archive-diff                  jardiff;
+    application/x-java-jnlp-file                     jnlp;
+    application/x-makeself                           run;
+    application/x-perl                               pl pm;
+    application/x-pilot                              prc pdb;
+    application/x-rar-compressed                     rar;
+    application/x-redhat-package-manager             rpm;
+    application/x-sea                                sea;
+    application/x-shockwave-flash                    swf;
+    application/x-stuffit                            sit;
+    application/x-tcl                                tcl tk;
+    application/x-x509-ca-cert                       der pem crt;
+    application/x-xpinstall                          xpi;
+    application/xhtml+xml                            xhtml;
+    application/xspf+xml                             xspf;
+    application/zip                                  zip;
+
+    application/octet-stream                         bin exe dll;
+    application/octet-stream                         deb;
+    application/octet-stream                         dmg;
+    application/octet-stream                         iso img;
+    application/octet-stream                         msi msp msm;
+
+    audio/midi                                       mid midi kar;
+    audio/mpeg                                       mp3;
+    audio/ogg                                        ogg;
+    audio/x-m4a                                      m4a;
+    audio/x-realaudio                                ra;
+
+    video/3gpp                                       3gpp 3gp;
+    video/mp2t                                       ts;
+    video/mp4                                        mp4;
+    video/mpeg                                       mpeg mpg;
+    video/quicktime                                  mov;
+    video/webm                                       webm;
+    video/x-flv                                      flv;
+    video/x-m4v                                      m4v;
+    video/x-mng                                      mng;
+    video/x-ms-asf                                   asx asf;
+    video/x-ms-wmv                                   wmv;
+    video/x-msvideo                                  avi;
+}

--- a/habitat/config/nginx.conf
+++ b/habitat/config/nginx.conf
@@ -1,0 +1,28 @@
+daemon off;
+pid {{pkg.svc_var_path}}/pid;
+worker_processes {{cfg.worker_processes}};
+
+events {
+  worker_connections {{cfg.events.worker_connections}};
+}
+
+http {
+  include        mime.types;
+  default_type   application/octet-stream;
+
+  client_body_temp_path {{pkg.svc_var_path}}/client-body;
+  fastcgi_temp_path {{pkg.svc_var_path}}/fastcgi;
+  proxy_temp_path {{pkg.svc_var_path}}/proxy;
+  scgi_temp_path {{pkg.svc_var_path}}/scgi_temp_path;
+  uwsgi_temp_path {{pkg.svc_var_path}}/uwsgi;
+
+  server {
+    listen {{cfg.port}} default_server;
+    server_name _;
+
+    location / {
+      root {{pkg.svc_data_path}};
+      index index.html index.htm;
+    }
+  }
+}

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -1,3 +1,9 @@
+worker_processes = "auto"
+port = 80
+
+[events]
+worker_connections = 512
+
 [general]
 hubs_server = "dev.reticulum.io"
 reticulum_server = "dev.reticulum.io"
@@ -10,4 +16,6 @@ ga_tracking_id = ""
 is_moz = false
 
 [deploy]
-type = "none"
+type = "serve"
+
+[server]

--- a/habitat/hooks/init
+++ b/habitat/hooks/init
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Make an empty HTML file to be served by default.
+touch "{{ pkg.svc_static_path }}/index.html"
+# Apply permissions allowing Nginx workers to read what's in our static path.
+chown hab:hab "{{ pkg.svc_static_path }}"

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -64,4 +64,9 @@ then
   cp -R "{{ cfg.deploy.target }}/spoke/pages/latest" "{{ cfg.deploy.target }}/spoke/pages/releases/{{ pkg.version }}.{{ pkg.release }}"
 fi
 
-exec sleep 999999999999
+
+if [[ "{{ cfg.deploy.type }}" == "serve" ]] ;
+then
+# Start the Nginx server, passing it our bundled configuration file.
+exec {{ pkgPathFor "core/nginx" }}/bin/nginx -c "{{ pkg.svc_config_path }}/nginx.conf" 2>&1
+fi

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=spoke
-pkg_origin=mozillareality
-pkg_maintainer="Mozilla Mixed Reality <mixreality@mozilla.com>"
+pkg_origin=xrchat
+pkg_maintainer="XRChat <hello@xrchat.social>"
 
 pkg_version="1.0.0"
 pkg_license=('MPLv2')
@@ -12,16 +12,18 @@ pkg_build_deps=(
     core/node10
     core/yarn
     core/git
+
 )
 
 pkg_deps=(
     core/aws-cli # AWS cli used for run hook when uploading to S3
+    core/nginx
 )
 
 do_build() {
   ln -s "$(hab pkg path core/coreutils)/bin/env" /usr/bin/env
   yarn config set cache-folder "$(pwd)/.cache" # Set the yarn cache to a directory in the current workspace so that it can be reused across ci builds
-  yarn install --frozen-lockfile
+  yarn install # --frozen-lockfile
 
   # We inject random tokens into the build that will be replaced at run webhook/deploy time with the actual runtime configs.
   export BASE_ASSETS_PATH="$(echo "base_assets_path" | sha256sum | cut -d' ' -f1)/" # HACK need a trailing slash so webpack'ed semantics line up
@@ -30,7 +32,7 @@ do_build() {
   yarn build
 
   mkdir -p dist/pages
-  mv dist/*.html dist/pages
+  cp dist/*.html dist/pages
 }
 
 do_install() {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "recast-wasm": "^0.1.1",
     "styled-components": "4.4.0",
     "styled-icons": "^8.4.2",
-    "three": "https://github.com/MozillaReality/three.js.git#0f9b0024725f0dd917caa54c2934a4ba1fc12c4f",
+    "three": "https://github.com/MozillaReality/three.js.git#hubs/master",
     "three-mesh-bvh": "^0.1.4",
     "url-toolkit": "^2.1.6",
     "use-debounce": "^3.4.0",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,7 @@
+set -e
+set -x
+
+STAGE=$1
+TAG=$2
+
+helm upgrade --reuse-values --set spoke.image.tag=$TAG $STAGE xrchat/xrchat

--- a/scripts/nginx.conf
+++ b/scripts/nginx.conf
@@ -1,0 +1,16 @@
+
+
+server {
+    listen  80;
+    listen  [::]:80;
+
+    
+    server_name xrchat.local localhost;
+    root  /usr/share/nginx/html;
+    index index.html;
+    
+    location / {
+        try_files $uri /index.html =404;
+    }
+    
+}

--- a/scripts/publish_dockerhub.sh
+++ b/scripts/publish_dockerhub.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+set -x
+
+STAGE=$1
+TAG=$2
+
+docker build --tag xrchat/spoke .
+echo "$DOCKER_HUB_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+
+docker tag xrchat/spoke xrchat/spoke:${STAGE}
+docker push xrchat/spoke:${STAGE}
+
+docker tag xrchat/spoke xrchat/spoke:${TAG}
+docker push xrchat/spoke:${TAG}

--- a/scripts/replace_env_stub.sh
+++ b/scripts/replace_env_stub.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+TEMP_DIST_PATH="./dist"
+
+# Replace base assets path in static references
+# find $TEMP_DIST_PATH -type f -name *.html -exec sed -i "s/$(echo "base_assets_path" | sha256sum | cut -d' ' -f1)\//${BASE_ASSETS_PATH}/g" {} \;
+# find $TEMP_DIST_PATH -type f -name *.css -exec sed -i "s/$(echo "base_assets_path" | sha256sum | cut -d' ' -f1)\//${BASE_ASSETS_PATH}/g" {} \;
+
+
+# Inject env by splitting file on expected BUILD_CONFIGS line
+cd $TEMP_DIST_PATH
+
+for f in *.html
+do
+  csplit $f /META_TAGS/ > /dev/null
+  cat xx00 > $f
+
+  echo "<meta name=\"env:hubs_server\" content=\"${HUBS_SERVER}\"/>" >> $f
+  echo "<meta name=\"env:reticulum_server\" content=\"${RETICULUM_SERVER}\"/>" >> $f
+  echo "<meta name=\"env:cors_proxy_server\" content=\"${CORS_PROXY_SERVER}\"/>" >> $f
+  echo "<meta name=\"env:thumbnail_server\" content=\"${THUMBNAIL_SERVER}\"/>" >> $f
+  echo "<meta name=\"env:non_cors_proxy_domains\" content=\"${NON_CORS_PROXY_DOMAINS}\"/>" >> $f
+  echo "<meta name=\"env:base_assets_path\" content=\"${BASE_ASSETS_PATH}\"/>" >> $f
+  echo "<meta name=\"env:sentry_dsn\" content=\"${SENTRY_DSN}\"/>" >> $f
+  echo "<meta name=\"env:ga_tracking_id\" content=\"${GA_TRACKING_ID}\"/>" >> $f
+  echo "<meta name=\"env:is_moz\" content=\"${IS_MOZ}\"/>" >> $f
+
+  cat xx01 >> $f
+  rm xx00
+  rm xx01
+done

--- a/scripts/setup_aws.sh
+++ b/scripts/setup_aws.sh
@@ -1,0 +1,14 @@
+set -e
+set -x
+
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+sudo ./aws/install
+
+set +x
+
+aws configure set aws_access_key_id $1
+aws configure set aws_secret_access_key $2
+aws configure set default.region $3
+
+aws eks update-kubeconfig --name $4

--- a/scripts/setup_helm.sh
+++ b/scripts/setup_helm.sh
@@ -1,0 +1,12 @@
+set -e
+set -x
+
+sudo snap install kubectl --classic
+
+sudo snap install helm --classic
+
+helm repo add xrchat https://xrchat.github.io/xrchat-ops/
+
+helm repo update
+
+set +x

--- a/scripts/write_env_stub.sh
+++ b/scripts/write_env_stub.sh
@@ -1,0 +1,4 @@
+set -e
+# We inject random tokens into the build that will be replaced at run webhook/deploy time with the actual runtime configs.
+export BASE_ASSETS_PATH="$(echo "base_assets_path" | sha256sum | cut -d' ' -f1)/" # HACK need a trailing slash so webpack'ed semantics line up
+export BUILD_VERSION="${pkg_version}.$(echo $pkg_prefix | cut -d '/' -f 7)"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12736,9 +12736,9 @@ three-mesh-bvh@^0.1.4:
   resolved "https://registry.yarnpkg.com/three-mesh-bvh/-/three-mesh-bvh-0.1.4.tgz#c392bcb9318224e0422aa939e855ca0ee45a831a"
   integrity sha512-RW16Adn4L7Z7aOWlkTPDAgIYyQZnI0izTERPxYF7cLb/AmExdm2fk6cXQCGzj5RkI8872KzlAKxZKMv/3LT/Lw==
 
-"three@https://github.com/MozillaReality/three.js.git#0f9b0024725f0dd917caa54c2934a4ba1fc12c4f":
-  version "0.105.1"
-  resolved "https://github.com/MozillaReality/three.js.git#0f9b0024725f0dd917caa54c2934a4ba1fc12c4f"
+"three@https://github.com/MozillaReality/three.js.git#hubs/master":
+  version "0.111.0"
+  resolved "https://github.com/MozillaReality/three.js.git#6dc1886802c936054ee5f48e8b39cc1be2e6e45f"
 
 throttle-debounce@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
fixes https://github.com/xrchat/xrchat-ops/issues/1#issuecomment-619109002

## Included:

1. Documentation on how to run
2. Travis CI, test, build and deploy using helm, it will respect the same branching and tagging models like xrchat-client
3. Image is configurable at runtime, so you can pass a HUBS_SERVER url in Env and it will respect it, even though it is a static react project 

## In progress in the xrchat-ops:
- update helm and compose to include Spoke

## Note:
Dockerize Spoke without habitat
I started to dockerize it with habitat too (to be compaitible with the upstream project), but it will take longer to configure the CI
